### PR TITLE
A fix for current Smoke (The one included with KDE 4.7, it seems)

### DIFF
--- a/commonqt.pro
+++ b/commonqt.pro
@@ -5,5 +5,5 @@ HEADERS     += commonqt.h
 SOURCES     += commonqt.cpp
 CONFIG      += qt thread debug dll
 
-unix:LIBS += -lsmokeqtcore
+unix:LIBS += -lsmokeqtcore -lsmokebase
 win32:LIBS += smokebase.lib


### PR DESCRIPTION
Without -lsmokebase, libcommonqt.so will fail loading because of uknown dynamic symbols:

```
* (qt-tutorial-14:main)


debugger invoked on a CFFI:LOAD-FOREIGN-LIBRARY-ERROR in thread #<THREAD
                                                                  "initial thread" RUNNING

                                                                  {1002911201}>:
  Unable to load foreign library (LIBRARY-936).
  Error opening shared object "/home/pl/quicklisp/dists/quicklisp/software/commonqt-20110522-git/libcommonqt.so":
  /home/pl/quicklisp/dists/quicklisp/software/commonqt-20110522-git/libcommonqt.so: undefined symbol: _ZN5Smoke8classMapE.

Type HELP for debugger help, or (SB-EXT:QUIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [RETRY    ] Try loading the foreign library again.
  1: [USE-VALUE] Use another library instead.
  2: [ABORT    ] Exit debugger, returning to top level.

(CFFI::FL-ERROR
 "Unable to load foreign library (~A).~%  ~A"
 #:LIBRARY-936
 "Error opening shared object \"/home/pl/quicklisp/dists/quicklisp/software/commonqt-20110522-git/libcommonqt.so\":
  /home/pl/quicklisp/dists/quicklisp/software/commonqt-20110522-git/libcommonqt.so: undefined symbol: _ZN5Smoke8classMapE.")

```
