### PR TITLE
Simple fix for RESOLVE-NEW to properly handle Phonon classes

### DIFF
--- a/primitive-call.lisp
+++ b/primitive-call.lisp
@@ -228,9 +228,14 @@
 (defun resolve-new (instance args &optional fix-types)
   ;; (format *trace-output* "cache miss for #_new ~A~%" instance)
   (let* ((class (qobject-class instance))
+         (class-name (qclass-name class))
+         (constructor (let ((colonpos (position #\: class-name :from-end T)))
+                        (if colonpos
+                            (subseq class-name (1+ colonpos))
+                            class-name)))
          (method
            (qclass-find-applicable-method class
-                                          (qclass-name class)
+                                          constructor
                                           args
                                           fix-types)))
     (unless method


### PR DESCRIPTION
Phonon classes return a class-name unsuitable for constructor usage. Phonon class names
are prefixed with "Phonon::" whereas their constructors do not contain
this prefix, and it must thus be removed to obtain the proper
constructor name to use QCLASS-FIND-APPLICABLE-METHOD.

This fixes #19 