### PR TITLE
Change PERFORM of MAKEFILE to Use qmake-qt4 If Available

### DIFF
--- a/qt.asd
+++ b/qt.asd
@@ -52,7 +52,7 @@
   (when (find-package :qt)
     (set (find-symbol (symbol-name '*loaded*) :qt) nil))
   (unless (zerop (run-shell-command
-                  "qmake ~A~S -o ~S"
+                  "$(hash qmake-qt4 2>/dev/null && echo \"qmake-qt4\" || echo \"qmake\") ~A~S -o ~S"
                   #+darwin "-spec macx-g++ " #-darwin ""
                   (namestring (component-pathname c))
                   (namestring (output-file o c))))


### PR DESCRIPTION
On systems with both Qt4 and Qt5 invoking `qmake` results in an error, as CommonQt currently only works with Qt4. This changes to command to check for the availability of `qmake-qt4` first, and if it exists to use that instead of `qmake`.